### PR TITLE
Breaking Changes: Rename `group` attribute to `validatorGroup`

### DIFF
--- a/addon/mixins/form-validator.js
+++ b/addon/mixins/form-validator.js
@@ -35,8 +35,8 @@ export default Ember.Mixin.create(
    * Instance of component form-validate
    * @type {?COMPONENT:form-validate}
    */
-  group: void 0,
-  _group: void 0,
+  validatorGroup: void 0,
+  _validatorGroup: void 0,
   /**
    * A group of validators, see light-form-validate's validators parameter of validate method.
    * @type {object|function|Array.<object>}
@@ -74,24 +74,24 @@ export default Ember.Mixin.create(
   _resetValidate() {
     this._updateErrorMessage();
   },
-  _formValidatorSetup: Ember.on('init', Ember.observer('group', function() {
-    const newGroup = this.get('group');
-    this._unregister(this.get('_group'));
-    this.set('_group', newGroup);
+  _formValidatorSetup: Ember.on('init', Ember.observer('validatorGroup', function() {
+    const newGroup = this.get('validatorGroup');
+    this._unregister(this.get('_validatorGroup'));
+    this.set('_validatorGroup', newGroup);
     if (!this.get('disabled')) {
       this._register(newGroup);
     }
   })),
   _formValidatorEnable: Ember.on('init', Ember.observer('disabled', function() {
     if (this.get('disabled')) {
-      this._unregister(this.get('group'));
+      this._unregister(this.get('validatorGroup'));
       this._resetValidate();
     } else {
-      this._register(this.get('group'));
+      this._register(this.get('validatorGroup'));
     }
   })),
   willDestroyElement() {
-    this._unregister(this.get('group'));
+    this._unregister(this.get('validatorGroup'));
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-form-validate",
-  "version": "0.0.1-beta.8",
+  "version": "0.0.1-beta.9",
   "description": "Ember form validate addon",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Breaking Changes: Rename `group` attribute to `validatorGroup` to avoid name conflict.